### PR TITLE
[FEATURE] Add SoC timestamp forwarding feature in Windows NDIS design

### DIFF
--- a/apps/demo_mn_embedded/src/main.c
+++ b/apps/demo_mn_embedded/src/main.c
@@ -13,7 +13,7 @@ application.
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 Copyright (c) 2013, SYSTEC electronic GmbH
-Copyright (c) 2017, Kalycito Infotech Private Ltd.All rights reserved.
+Copyright (c) 2017, Kalycito Infotech  Private Ltd.All rights reserved.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
 - This commit introduces the SoC time forwarding capability
   to the Windows NDIS intermediate design using a shared memory.
 - Create a shared memory between kernel and user to hold SoC
   time stamps.
 - Release the shared memory during exit.